### PR TITLE
Add workaround for Products.CMFCore < 2.3.0 bug when user ID and login ID are different

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Changelog
 
 * Add email domain verification option.
   [ivanteoh]
+* Fix users not being able to be deactivated if their login id is different to their user id.
+  [JeffersonBledsoe]
 
 1.5 (2017-03-08)
 ----------------

--- a/collective/pfg/signup/adapter.py
+++ b/collective/pfg/signup/adapter.py
@@ -670,6 +670,35 @@ class SignUpAdapter(FormActionAdapter):
 
         return
 
+    def _setSecurityProfile(
+        self, user_data, password=None, roles=None, domains=None
+    ):
+        """
+        A bug in Products.CMFCore versions < 2.3.0 causes a failure to find
+        users whose login ID is different to their user ID. The below code
+        will use Products.CMFCore if the version has the fix, otherwise,
+        it will use a copy-pasted version. See the following commit for more details on the fix:
+        https://github.com/zopefoundation/Products.CMFCore/commit/570dea37248913c6c448f4783b4ef459f9a5456f
+        """
+
+        # Products.CMFCore was upgraded past 2.3.0 in Plone 5.2
+        # See: https://github.com/plone/buildout.coredev/commit/557884e51426c9fa8d3af63aed8e7777509c285b
+        if api.env.plone_version < '5.2':
+            user_data.setSecurityProfile(password=password)
+            return
+
+        user = user_data.getUser()
+
+        # The Zope User API is stupid, it should check for None.
+        if roles is None:
+            roles = list(user.getRoles())
+            if 'Authenticated' in roles:
+                roles.remove('Authenticated')
+        if domains is None:
+            domains = user.getDomains()
+
+        user.userFolderEditUser(user.getId(), password, roles, domains)
+
     def user_deactivate(self, user_id):
         """Deactivate user with user_id.
 
@@ -712,6 +741,7 @@ class SignUpAdapter(FormActionAdapter):
                 'last_updated_date': current_time})
             passwd = self.id_generator(size=32)
             user.setSecurityProfile(password=passwd)
+            self._setSecurityProfile(user_data=user, password=passwd)
             self.plone_utils.addPortalMessage(
                 _(u'This user is deactivated.'))
         except (AttributeError, ValueError) as err:


### PR DESCRIPTION
In Products.CMFCore version below 2.3.0, there was a bug within `setSecurityProfile` where it would fail to find a user if the user ID did not match the login ID. This PR implements the same function found within Products.CMFCore but with the [fix applied by Products.CMFCore 2.3.0](https://github.com/zopefoundation/Products.CMFCore/commit/570dea37248913c6c448f4783b4ef459f9a5456f).

Plone 5.2.0 onwards use a later version of Products.CMFCore, and so `setSecurityProfile` will be called instead for users on those versions.